### PR TITLE
[#IOPID-280] Filter non lollipop headers, fix blob save

### DIFF
--- a/src/functions/__tests__/fast-login.test.ts
+++ b/src/functions/__tests__/fast-login.test.ts
@@ -274,7 +274,6 @@ describe("Fast Login handler", () => {
   it.each`
     WHEN                                      | upsertBlobFromObjectResult                    | expectedErrorMessage                                                 | resolve
     ${"the blob storage returns no result"}   | ${E.right(O.none)}                            | ${"The audit log was not saved"}                                     | ${true}
-    ${"the blob wasn't created"}              | ${E.right(O.some({ created: false }))}        | ${"The audit log was not saved"}                                     | ${true}
     ${"the blob sorage returns an error"}     | ${E.left(new Error("Storage Error Message"))} | ${"An error occurred saving the audit log: [Storage Error Message]"} | ${true}
     ${"the blob sorage unexpectedly rejects"} | ${new Error("Unexpected error")}              | ${"Unexpected error: [Unexpected error]"}                            | ${false}
   `(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
The headers have now an `exact` decoder.
The response from `upsertBlobFromObject` is evaluated as an error only if is a `none` value.
<!--- Describe your changes in detail -->

#### Motivation and Context
The audit logs are saved but additional headers are stored into the file, even with reserved information like the function auth token.
The response from `upsertBlobFromObject` doesn't contains the `created: true` property but the blob is created.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not tested

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
