### PR TITLE
[#IOPID-1642] Fix ReDOS vulnerability on SignatureInput header decoder

### DIFF
--- a/api/internal.yaml
+++ b/api/internal.yaml
@@ -457,7 +457,7 @@ components:
       minLength: 1
     LollipopSignatureInput:
       type: string
-      pattern: ^(((sig[0-9]+)=[^,]*?)(, ?)?)+$
+      pattern: ^(?:sig\d+=[^,]*)(?:,\s*(?:sig\d+=[^,]*))*$
     LollipopSignature:
       type: string
       pattern: ^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$

--- a/api/internal.yaml.template
+++ b/api/internal.yaml.template
@@ -403,7 +403,7 @@ components:
       minLength: 1
     LollipopSignatureInput:
       type: string
-      pattern: "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+      pattern: "^(?:sig\\d+=[^,]*)(?:,\\s*(?:sig\\d+=[^,]*))*$"
     LollipopSignature:
       type: string
       pattern: "^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$"

--- a/src/__tests__/lollipop-signature-input.test.ts
+++ b/src/__tests__/lollipop-signature-input.test.ts
@@ -1,0 +1,16 @@
+import { LollipopSignatureInput } from "../generated/definitions/internal/LollipopSignatureInput";
+import * as E from "fp-ts/Either";
+
+const aValidSignatureInput = `sig1=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "x-pagopa-original-url" "x-pagopa-original-method");created=1618884475;keyid="test-key-ecc-p256", sig2=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "forwarded");created=1618884480;keyid="test-key-rsa";alg="rsa-v1_5-sha256";expires=1618884540`;
+const anInvalidSignatureInput = `anInvalidStringInput`;
+describe("LollipopSignatureInput type decoder", () => {
+  it("should decode successfully a valid signature-input string", () => {
+    const result = LollipopSignatureInput.decode(aValidSignatureInput);
+    expect(E.isRight(result)).toBeTruthy();
+  });
+
+  it("should return an error if an invalid signatur-input is provided", () => {
+    const result = LollipopSignatureInput.decode(anInvalidSignatureInput);
+    expect(E.isLeft(result)).toBeTruthy();
+  });
+});

--- a/src/__tests__/lollipop-signature-input.test.ts
+++ b/src/__tests__/lollipop-signature-input.test.ts
@@ -2,7 +2,9 @@ import { PatternString } from "@pagopa/ts-commons/lib/strings";
 import { LollipopSignatureInput } from "../generated/definitions/internal/LollipopSignatureInput";
 import * as E from "fp-ts/Either";
 
+// A LolliPoP valid SignatureInput with multiple signature
 const aValidMultiSignatureInput = `sig1=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "x-pagopa-original-url" "x-pagopa-original-method");created=1618884475;keyid="test-key-ecc-p256", sig2=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "forwarded");created=1618884480;keyid="test-key-rsa";alg="rsa-v1_5-sha256";expires=1618884540`;
+// A LolliPoP valid SignatureInput with single signature
 const aValidSingleSignatureInput = `sig1=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "x-pagopa-original-url" "x-pagopa-original-method");created=1618884475;keyid="test-key-ecc-p256"`;
 
 // The following string is an example of input value that can execute a ReDOS

--- a/src/__tests__/lollipop-signature-input.test.ts
+++ b/src/__tests__/lollipop-signature-input.test.ts
@@ -1,16 +1,34 @@
+import { PatternString } from "@pagopa/ts-commons/lib/strings";
 import { LollipopSignatureInput } from "../generated/definitions/internal/LollipopSignatureInput";
 import * as E from "fp-ts/Either";
 
-const aValidSignatureInput = `sig1=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "x-pagopa-original-url" "x-pagopa-original-method");created=1618884475;keyid="test-key-ecc-p256", sig2=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "forwarded");created=1618884480;keyid="test-key-rsa";alg="rsa-v1_5-sha256";expires=1618884540`;
+const aValidMultiSignatureInput = `sig1=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "x-pagopa-original-url" "x-pagopa-original-method");created=1618884475;keyid="test-key-ecc-p256", sig2=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "forwarded");created=1618884480;keyid="test-key-rsa";alg="rsa-v1_5-sha256";expires=1618884540`;
+const aValidSingleSignatureInput = `sig1=("@method" "@authority" "@path" "content-digest" "content-type" "content-length" "x-pagopa-original-url" "x-pagopa-original-method");created=1618884475;keyid="test-key-ecc-p256"`;
+
+// The following string is an example of input value that can execute a ReDOS
+// attack over the old regex "^(((sig[0-9]+)=[^,]*?)(, ?)?)+$"
+const attackValue = "sig0=, " + "sig0=sig0=, ".repeat(27) + ",s";
 const anInvalidSignatureInput = `anInvalidStringInput`;
+
 describe("LollipopSignatureInput type decoder", () => {
   it("should decode successfully a valid signature-input string", () => {
-    const result = LollipopSignatureInput.decode(aValidSignatureInput);
-    expect(E.isRight(result)).toBeTruthy();
+    const multiSignatureResult = LollipopSignatureInput.decode(
+      aValidMultiSignatureInput
+    );
+    const singleSignatureResult = LollipopSignatureInput.decode(
+      aValidSingleSignatureInput
+    );
+    expect(E.isRight(multiSignatureResult)).toBeTruthy();
+    expect(E.isRight(singleSignatureResult)).toBeTruthy();
   });
 
   it("should return an error if an invalid signatur-input is provided", () => {
     const result = LollipopSignatureInput.decode(anInvalidSignatureInput);
+    expect(E.isLeft(result)).toBeTruthy();
+  });
+
+  it("should be safe process a string that cause a ReDOS on the old regex ^(((sig[0-9]+)=[^,]*?)(, ?)?)+$", () => {
+    const result = LollipopSignatureInput.decode(attackValue);
     expect(E.isLeft(result)).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
New regex on `LollipopSignatureInput` parameter

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The previous regex is vulnerable to ReDOS attach

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
